### PR TITLE
inventa-api-new-env-var-names

### DIFF
--- a/charts/inventa-api/Chart.yaml
+++ b/charts/inventa-api/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: inventa-api
-description: A Helm chart for Kubernetes
+description: A Helm chart for inventa-api which acts as a master for multiple inventa-operators
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.1.0
+appVersion: 1.0.0

--- a/charts/inventa-api/templates/deployment.yaml
+++ b/charts/inventa-api/templates/deployment.yaml
@@ -34,13 +34,13 @@ spec:
           env:
             - name: INVENTA_API_AUTH_ENABLE
               value: "{{ .Values.inventa.authEnable }}"
-            - name: INVENTA_API_AUTH_CLIENT_ID
+            - name: INVENTA_API_AzureAd__ClientId
               value: "{{ .Values.inventa.authClientId }}"
             - name: INVENTA_API_AUTH_CLIENT_SECRET
               value: "{{ .Values.inventa.authClientSecret }}"
             - name: INVENTA_API_AUTH_CLIENT_SCOPES
               value: "{{ .Values.inventa.authClientScopes }}"
-            - name: INVENTA_API_AUTH_TENANT_ID
+            - name: INVENTA_API_AzureAd__TenantId
               value: "{{ .Values.inventa.authTenantId }}"
             - name: INVENTA_API_OPERATOR_URLS
               value: "{{ .Values.inventa.operatorUrls }}"


### PR DESCRIPTION
This PR updates the inventa-api chart to use the new variable names for ClientID and TenantID for its Azure AD authentication