### PR TITLE
add allowed api group option

### DIFF
--- a/charts/crossplane-operator-dfds/Chart.yaml
+++ b/charts/crossplane-operator-dfds/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.16.0
+appVersion: 0.1.2

--- a/charts/crossplane-operator-dfds/Chart.yaml
+++ b/charts/crossplane-operator-dfds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: crossplane-operator-dfds
-description: A Helm chart for Kubernetes
+description: A Helm chart for the crossplane dfds operator
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/charts/crossplane-operator-dfds/Chart.yaml
+++ b/charts/crossplane-operator-dfds/Chart.yaml
@@ -20,4 +20,4 @@ version: 0.1.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.1.2
+appVersion: 0.0.2

--- a/charts/crossplane-operator-dfds/templates/deployment.yaml
+++ b/charts/crossplane-operator-dfds/templates/deployment.yaml
@@ -39,6 +39,8 @@ spec:
               value: {{ .Values.crossplaneOperatorDfds.enableAnnotionName }}
             - name: DFDS_CROSSPLANE_AWS_ACCOUNT_ID_ANNOTATION_NAME
               value: {{ .Values.crossplaneOperatorDfds.awsAccountAnnotationName }}
+            - name: DFDS_CROSSPLANE_PKG_ALLOWED_API_GROUPS
+              value: {{ .Values.crossplaneOperatorDfds.allowedApiGroups }}
               
           # ports:
           #   - name: http

--- a/charts/crossplane-operator-dfds/templates/role.yaml
+++ b/charts/crossplane-operator-dfds/templates/role.yaml
@@ -111,4 +111,56 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - rbac
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac
+  resources:
+  - rolebindings/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - rbac
+  resources:
+  - rolebindings/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - rbac
+  resources:
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac
+  resources:
+  - roles/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - rbac
+  resources:
+  - roles/status
+  verbs:
+  - get
+  - patch
+  - update
 {{- end }}  

--- a/charts/crossplane-operator-dfds/values.yaml
+++ b/charts/crossplane-operator-dfds/values.yaml
@@ -8,11 +8,12 @@ image:
   repository: dfdsdk/crossplane-operator-dfds-controller
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.0.1"
+  tag: "v0.0.2"
 
 crossplaneOperatorDfds:
   enableAnnotionName: "dfds-crossplane-enabled"
   awsAccountAnnotationName: "dfds-aws-account-id"
+  allowedApiGroups: "storage.xplane.dfds.cloud,certs.xplane.dfds.cloud,cdn.xplane.dfds.cloud,dns.xplane.dfds.cloud,messaging.xplane.dfds.cloud,cache.xplane.dfds.cloud,identity.xplane.dfds.cloud,database.xplane.dfds.cloud,networking.xplane.dfds.cloud"
 
 rbac:
   create: true


### PR DESCRIPTION
This PR updates the default version of the crossplane-operator and adds the crossplaneOperatorDfds.allowedApiGroups for the allowed configuration package rbac roles